### PR TITLE
Bug fix: disk size needs to be a string; change default size to to 20GiB

### DIFF
--- a/vagrant-centos.json
+++ b/vagrant-centos.json
@@ -7,7 +7,7 @@
       "guest_additions_path": "",
       "redhat_release": "",
       "redhat_platform": "",
-      "disk_size": "20000"
+      "disk_size": "20480"
     },
 
   "builders": [

--- a/variables-centos-6.json
+++ b/variables-centos-6.json
@@ -5,5 +5,5 @@
   "guest_additions_path": "VBoxGuestAdditions.iso",
   "redhat_release": "6.7",
   "redhat_platform": "x86_64",
-  "disk_size": "20000"
+  "disk_size": "20480"
 }

--- a/variables-centos-7.json
+++ b/variables-centos-7.json
@@ -5,5 +5,5 @@
   "guest_additions_path": "VBoxGuestAdditions.iso",
   "redhat_release": "7.3.1511",
   "redhat_platform": "x86_64",
-  "disk_size": 20000
+  "disk_size": "20480"
 }


### PR DESCRIPTION
This fixes the following error when running `packer build -var-file=variables-centos-7.json vagrant-centos.json`

```
invalid value "variables-centos-7.json" for flag -var-file: Error reading variables in 'variables-centos-7.json': json: cannot unmarshal number into Go value of type string
```
